### PR TITLE
Generate comprehensive api documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 - 😄 Pronouns: ...
 - ⚡ Fun fact: ...
 
+## Documentation
+- API Reference: [docs/API_REFERENCE.md](docs/API_REFERENCE.md)
+- Usage Examples: [docs/USAGE_EXAMPLES.md](docs/USAGE_EXAMPLES.md)
+- Docs Guide: [docs/CONTRIBUTING_DOCS.md](docs/CONTRIBUTING_DOCS.md)
+
 <!---
 Dbavalia/Dbavalia is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,103 @@
+# API Reference
+
+This document lists all publicly exposed APIs, functions, classes, and components.
+
+Current inventory
+- No public APIs detected in the repository yet.
+
+How to add new API entries
+- Prefer documenting directly alongside code using language-native doc comments. See examples below.
+- Each public item should include: purpose, parameters, return values, possible errors, and at least one runnable example.
+
+Templates by language
+
+JavaScript / TypeScript
+```ts
+/**
+ * Concise one-line summary.
+ *
+ * Longer description with context and behavior.
+ *
+ * @example
+ * import { doThing } from "@your-scope/your-pkg";
+ * const result = await doThing({ flag: true });
+ * console.log(result.value);
+ *
+ * @param options - Description of options
+ * @returns Useful result description
+ * @throws ErrorType when ...
+ */
+export async function doThing(options: { flag: boolean }): Promise<{ value: number }> {
+  // ...
+}
+```
+
+React component (TSX)
+```tsx
+/** Button that triggers an action. */
+export function PrimaryButton(props: { label: string; onClick: () => void }) {
+  return <button onClick={props.onClick}>{props.label}</button>;
+}
+
+/**
+ * @example
+ * <PrimaryButton label="Save" onClick={() => save()} />
+ */
+```
+
+Python
+```python
+def do_thing(flag: bool) -> int:
+    """Concise one-line summary.
+
+    Longer description with context and behavior.
+
+    Args:
+        flag: Description
+    Returns:
+        int: Useful result description
+    Raises:
+        ValueError: when ...
+
+    Examples:
+        >>> do_thing(True)
+        42
+    """
+    pass
+```
+
+Go
+```go
+// DoThing performs the operation.
+//
+// Example:
+//  out, err := DoThing(Options{Flag: true})
+//  if err != nil { log.Fatal(err) }
+//  fmt.Println(out.Value)
+func DoThing(opts Options) (Result, error) {
+    // ...
+}
+```
+
+Rust
+```rust
+/// Performs the operation.
+///
+/// # Examples
+/// ```
+/// let out = crate::do_thing(true);
+/// assert!(out.value > 0);
+/// ```
+pub fn do_thing(flag: bool) -> Result<i32, Error> {
+    // ...
+}
+```
+
+Documentation checklist per item
+- Name and short summary
+- Detailed description and assumptions
+- Parameters and types
+- Return type and shape
+- Errors and edge cases
+- Examples (happy-path and failure)
+- Version introduced / breaking changes

--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -1,0 +1,30 @@
+# Contributing to Documentation
+
+Scope
+- This guide explains how to document public APIs, functions, classes, and components.
+
+General rules
+- Document only public, supported surfaces. Mark experimental with clear labels.
+- Keep examples runnable and minimal.
+- Document error conditions and edge cases.
+- Update docs in the same change as code when behavior changes.
+
+Style
+- Use clear, active voice. Prefer short sentences.
+- Use language-native doc comments plus dedicated markdown pages when needed.
+- Provide both a quick-start example and an advanced usage example for complex APIs.
+
+Structure for each API item
+- Summary
+- Detailed behavior
+- Parameters and types
+- Returns
+- Errors
+- Examples
+- Since / Deprecated
+
+Verification checklist for PRs
+- [ ] New/changed APIs are documented
+- [ ] Examples compile/run
+- [ ] Links updated (TOC, cross-references)
+- [ ] Breaking changes called out

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Project Documentation
+
+Welcome to the project documentation. This space aggregates API references, examples, and authoring guidelines.
+
+- See API reference: [docs/API_REFERENCE.md](./API_REFERENCE.md)
+- See usage examples: [docs/USAGE_EXAMPLES.md](./USAGE_EXAMPLES.md)
+- See docs contribution guide: [docs/CONTRIBUTING_DOCS.md](./CONTRIBUTING_DOCS.md)
+
+Status
+- No public APIs were detected in the repository at the time these docs were generated.
+- As you add code, follow the contribution guide to keep this documentation current.

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -1,0 +1,63 @@
+# Usage Examples
+
+This guide shows how consumers should import and use your public APIs. Replace placeholders when APIs are added.
+
+JavaScript / TypeScript
+```ts
+// Installation (example)
+// npm install @your-scope/your-pkg
+
+// Importing a function
+import { doThing } from "@your-scope/your-pkg";
+
+async function run() {
+  const result = await doThing({ flag: true });
+  console.log(result.value);
+}
+
+run();
+```
+
+React Components
+```tsx
+import { PrimaryButton } from "@your-scope/your-pkg";
+
+export default function Page() {
+  return <PrimaryButton label="Save" onClick={() => console.log("clicked")} />;
+}
+```
+
+Python
+```python
+# pip install your-package
+from your_package import do_thing
+
+print(do_thing(True))
+```
+
+Go
+```go
+import (
+    "github.com/your-org/your-pkg"
+)
+
+func main() {
+    out, err := yourpkg.DoThing(yourpkg.Options{Flag: true})
+    if err != nil { panic(err) }
+    println(out.Value)
+}
+```
+
+Rust
+```rust
+use your_crate::do_thing;
+
+fn main() {
+    let out = do_thing(true).unwrap();
+    println!("{}", out.value);
+}
+```
+
+Notes
+- Replace package names with actual module names when available.
+- Include error-handling examples where relevant.


### PR DESCRIPTION
Add a documentation scaffold under `docs/` and link it from the root `README.md`, as no public APIs were found to document.

---
<a href="https://cursor.com/background-agent?bcId=bc-53ee1a91-9949-460c-8f66-d8c4e8dfafdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-53ee1a91-9949-460c-8f66-d8c4e8dfafdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

